### PR TITLE
Updating dependencies to avoid CVEs

### DIFF
--- a/demos/demo-app/pom.xml
+++ b/demos/demo-app/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-client</artifactId>
-            <version>3.3.1</version>
+            <version>3.3.4</version>
             <scope>compile</scope>
         </dependency>
 

--- a/demos/demo-app/pom.xml
+++ b/demos/demo-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.0.RELEASE</version>
+        <version>2.3.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/demos/demo-bot/pom.xml
+++ b/demos/demo-bot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.0.RELEASE</version>
+		<version>2.3.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
     <groupId>com.github.deutschebank.symphony</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-boot.version>2.2.0.RELEASE</spring-boot.version>
+		<spring-boot.version>2.3.2.RELEASE</spring-boot.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 

--- a/shared-stream/pom.xml
+++ b/shared-stream/pom.xml
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-rs-client</artifactId>
-			<version>3.3.1</version>
+			<version>3.3.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/symphony-api-spring-boot-starter/pom.xml
+++ b/symphony-api-spring-boot-starter/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-rs-client</artifactId>
-			<version>3.3.1</version>
+			<version>3.3.4</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/symphony-app-spring-boot-starter/pom.xml
+++ b/symphony-app-spring-boot-starter/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-rs-client</artifactId>
-			<version>3.3.1</version>
+			<version>3.3.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
As per title. Dependencies updated:

- spring-boot-starter-parent : from 2.2.0 to 2.3.2
- cxf-rt-rs-client : from 3.3.1 to 3.3.4 